### PR TITLE
Updated SirData new behaviour

### DIFF
--- a/src/nc.js
+++ b/src/nc.js
@@ -30,9 +30,14 @@
     }
   }
 
-  function elClick(selector, callback) {
+  function elClick(selector, callback, targetParent = false) {
     waitForElement(selector, () => {
-      document.querySelector(selector).click();
+      // target parent element
+      if (targetParent) {
+        document.querySelector(selector).parentNode.click();
+      } else {
+        document.querySelector(selector).click();
+      }
 
       if (callback) {
         callback();
@@ -130,12 +135,13 @@
       }
 
       // sirdata
+	  // 20201001 - Updated to target parents button (given class are those of span childs)
       if (!!window.Sddan && window.Sddan.cmpLoaded) {
-        elClick('.sd-cmp-scPzo', () => {
-          elClick('.sd-cmp-25WIV', () => {
-            elClick('.sd-cmp-2HNNR', () => clearInterval(kick));
-          });
-        });
+        elClick('.sd-cmp-2Pci8.sd-cmp-1BHAu.sd-cmp-1jg0y', () => {
+          elClick('.sd-cmp-2Pci8.sd-cmp-1xpje.sd-cmp-1jg0y', () => {
+            elClick('.sd-cmp-2Pci8.sd-cmp-1BHAu.sd-cmp-1U8T_', () => clearInterval(kick), true);
+          }, true);
+        }, true);
       }
 
       // appconsent


### PR DESCRIPTION
Allow targeting parent elements to click to match SirData new behaviour, with updated classes.
Related to issue #43.

elClick function was updated to allow a third parameter, to specify if we should target the parent element of the one matching the given selector(s).

Tested with Chrome and it works well.