### PR TITLE
Fix for issue #54.

### DIFF
--- a/src/nc.js
+++ b/src/nc.js
@@ -87,13 +87,17 @@
   const kick = setInterval(function () {
     try {
       // Didomi
-      if (!!window.Didomi && !!window.Didomi.setUserDisagreeToAll) {
-        window.Didomi.setUserDisagreeToAll();
-
-        // It has to be told multiple times "no" to understand "no"
-        if (didMoronUnderstood()) {
-          clearInterval(kick);
-        }
+      if (!!window.Didomi && !! window.didomiOnReady) {
+        window.didomiOnReady.push(function (Didomi) { 
+          if (Didomi.notice.isVisible() && !!Didomi.setUserDisagreeToAll) {
+            Didomi.setUserDisagreeToAll();
+            document.querySelectorAll('#didomi-host')
+              .forEach( function(d) {
+                d.setAttribute('aria-hidden', 'true');
+                d.style.display = 'none';
+              });
+          }
+        });
       }
 
       // consentmanager


### PR DESCRIPTION
On fip.fr didomi SDK is set such that on each consent update the page get reloaded. This conflict with the addon as it tries to send "no-consent" on every load.
It now checks the notice visibility beforehand which needed a whole new logic that waits for didomi to be fully loaded.

Also on some malformed sites the notice div is included more that once (eg. iadvize.com)
It seems then that when denying consent only one div get hidden whereas the consent state is actually saved.
So notice div are simply iterated on to properly hide every one.
