### PR TITLE
#3 : Manage chandago (from sfbx, now appconsent)

### DIFF
--- a/src/nc.js
+++ b/src/nc.js
@@ -229,6 +229,12 @@
           elClick('.slshield-info__cta.slshield-info__cta-accept', () => clearInterval(kick));
         }
       }
+      
+      //chandago / sfbx / appconsent
+      if (!!window.appconsent && document.getElementById('appconsent') != null && !!appconsent.default && !!appconsent.default.isInitialised) {
+          appconsent.default.deny();
+          clearInterval(kick);
+      }
     } catch (except) {
       console.error('[extension:Never-Consent] encountered a problem, please open an issue here https://github.com/MathRobin/Never-Consent/issues');
       console.error('[extension:Never-Consent]', except);


### PR DESCRIPTION
Seems not to be used anymore on any "reference" customer listed on [appconsent.io](https://appconsent.io)
I will try to find again the website I tested it on