### PR TITLE
Manage a (very ?) rarely used CMP

### DIFF
--- a/src/nc.js
+++ b/src/nc.js
@@ -253,6 +253,26 @@
         appconsent.default.deny();
         clearInterval(kick);
       }
+      
+      // cookieconsent(.fallback) / epaas (ex-BMW)
+      if (((!!window.consentcontroller && !!consentcontroller.api) ||
+           (!!window.cookiecontroller && !!cookiecontroller.api) ||
+           (!!window.epaas && !!epaas.api))) {
+              
+          if (!!window.consentcontroller && !!consentcontroller.api) {
+              var api = consentcontroller.api;
+          }
+          else if (!!window.cookiecontroller && !!cookiecontroller.api) {
+              var api = cookiecontroller.api;
+          }
+          else {
+              var api = epaas.api;
+          }
+          if (!!api.registerOnInitialized) {
+            api.registerOnInitialized(() => {api.setRegulationRejected()});
+            clearInterval(kick);
+          }
+      }
     } catch (except) {
       console.error('[extension:Never-Consent] encountered a problem, please open an issue here https://github.com/MathRobin/Never-Consent/issues');
       console.error('[extension:Never-Consent]', except);


### PR DESCRIPTION
Referred as cookiecontroller.fallback or consentcontroller(.fallback) or also epaas.

Was in use on BMW websites until few days ago. Now I cannot find any other.
Might not worth to get merged